### PR TITLE
Changed wording to be gender-neutral

### DIFF
--- a/_includes/reasoning/css/sass.html
+++ b/_includes/reasoning/css/sass.html
@@ -1,6 +1,6 @@
 <ol class="aside__info-list">
   <li class="aside__info-list-item"><span>SASS has many powerful tools, but these can make your code difficult to
-    maintain if you're not careful and confusing for the next guy who touches it.</span></li>
+    maintain if you're not careful and confusing for the next person who touches it.</span></li>
   <li class="aside__info-list-item"><span>On any decent-sized site, specificity
     problems can and will arise rather quickly. Extending your components
     later will be difficult as well.</span></li>


### PR DESCRIPTION
Hey @mfouquet, nice work on this manual. Just a quick amend here: Using the word "guy" as a general stand-in for "developer" or just "person" can be pretty exclusive to people who don't consider themselves as a _guy_. Replacing it with "person" doesn't make the wording sound any worse, but makes sure it doesn't exclude anyone.
