### PR TITLE
Reduce line breaks between HTML elements to a single line

### DIFF
--- a/_includes/code/courtesies.html
+++ b/_includes/code/courtesies.html
@@ -2,8 +2,6 @@
   ...
 </div>
 
-
-
 <div class="comment-list">
   ...
 </div> <!--end comment-list-->

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ layout: default
   <main class="main">
     <h5 class="main__title-border"><span class="main__title">Courtesies</span></h3>
     <ul class="main__list">
-      <li class="main__list-item">Put three line breaks between blocks/components.</li>
+      <li class="main__list-item">Put a single line break between blocks/components.</li>
       <li class="main__list-item">Avoid adding comments. An exception would be a closing comment
         for large blocks. <sup>1</sup></li>
     </ul>


### PR DESCRIPTION
This unnecessary amount of white space doesn't improve readability and makes files harder to navigate. A single blank line will suffice quite nicely. There is no reasoning given either, which makes it feel like an arbitrary matter of taste.

Line breaks between overall blocks aren't specified in the following style guides, but either a single line or no space could be inferred:
- Google: https://google.github.io/styleguide/htmlcssguide.xml#General_Formatting
- Github: http://primercss.io/guidelines/#general-formatting
- @mdo: http://codeguide.co
- jQuery: https://contribute.jquery.org/style-guide/html/
- Mapbox: https://www.mapbox.com/base/tutorials/single-column-list/ (for actual HTML code example)
- Mailchimp: http://ux.mailchimp.com/patterns/forms
- US Government: https://playbook.cio.gov/designstandards/grids/ (see code example halfway down)
- Gov.uk: https://github.com/alphagov/styleguides/blob/master/html.md (no mention of line break convention) http://govuk-elements.herokuapp.com/layout/ (code example)
